### PR TITLE
Clean up leftovers after removing boilerplate, labs, and sandbox

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,3 @@ updates:
   schedule:
     interval: weekly
     time: '20:00'
-- package-ecosystem: bundler
-  directories:
-    - "/boilerplate/rails61"
-    - "/boilerplate/rails70"
-    - "/boilerplate/rails71"
-    - "/boilerplate/rails72"
-    - "/boilerplate/rails80"
-    - "/boilerplate/rails81"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 0

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,0 @@
-sandbox:
-- changed-files:
-  - all-globs-to-all-files: 'sandbox/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go', 'javascript', 'python', 'ruby' ]
+        language: [ 'javascript', 'ruby' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ gem 'kramdown'
 gem 'net-scp'
 gem 'ed25519'
 
-gem 'hikidoc'
-
 gem "parallel", "~> 2.1"
 
 gem "slack-ruby-client", "~> 3.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,6 @@ GEM
       ostruct
     hashie (5.1.0)
       logger
-    hikidoc (0.1.1)
     json (2.20.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
@@ -95,7 +94,6 @@ PLATFORMS
 
 DEPENDENCIES
   ed25519
-  hikidoc
   kramdown
   mina
   net-scp
@@ -106,7 +104,6 @@ DEPENDENCIES
 
 CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
-  bundler (4.0.14) sha256=d09a0a965cf772266a7e49e83610be7c2f4e49e61134c42a56804bb383cc24b8
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-mashify (1.0.2) sha256=ebdc93b3f807af9a4b18c3d967fc7bcda01e297aed9cc2015ffe8db6e7add2e9
@@ -114,7 +111,6 @@ CHECKSUMS
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   gli (2.22.2) sha256=580e8d6c88b0f0f0cb8e8b2ca18c3485ed0f742cece855de46bf8e36202f5db0
   hashie (5.1.0) sha256=c266471896f323c446ea8207f8ffac985d2718df0a0ba98651a3057096ca3870
-  hikidoc (0.1.1) sha256=83938aee65028a73220764617dc95ab0e3e4daf0d774577825f64fb4e0f1c1dd
   json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
@@ -147,4 +143,4 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
 
 BUNDLED WITH
-  4.0.2
+  4.1.0.dev

--- a/Rakefile
+++ b/Rakefile
@@ -63,30 +63,3 @@ task :purge_system_env do
     FileUtils.rm File.expand_path("~/Library/LaunchAgents/#{k}.SetEnv.plist")
   end
 end
-
-RAILS_VERSIONS = {
-  "8.1" => "rails81",
-  "8.0" => "rails80",
-  "7.2" => "rails72",
-  "7.1" => "rails71",
-  "7.0" => "rails70",
-}
-
-namespace :boilerplate do
-  desc "regenerate all boilerplate Rails apps with latest patch versions"
-  task :update do
-    RAILS_VERSIONS.each do |version, dir|
-      dest = File.expand_path("boilerplate/#{dir}", __dir__)
-      puts "==> Recreating #{dir} (Rails ~> #{version})"
-
-      FileUtils.rm_rf(dest)
-      system("gem install rails -v '~> #{version}.0' --no-document", exception: true)
-      installed = `gem list -e rails`.match(/rails \(([^)]+)\)/)[1]
-      latest = installed.split(", ").select { |v| v.start_with?(version) }.first
-      system("rails", "_#{latest}_", "new", dest, exception: true)
-      FileUtils.rm_rf(Dir.glob("#{dest}/**/tmp/cache/bootsnap"))
-
-      puts "    #{dir} created"
-    end
-  end
-end

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,0 @@
-module github.com/hsbt/hsbt
-
-go 1.19


### PR DESCRIPTION
This removes files left behind after the `boilerplate`, `labs`, and `sandbox` directories were deleted. The `namespace :boilerplate` task in `Rakefile` regenerated the now-gone `boilerplate/rails*` apps and the matching `.github/dependabot.yml` bundler entries scanned them, so both are dropped. `.github/labeler.yml` only labeled `sandbox/**` and no workflow consumed it, `go.mod` had no remaining Go sources, and `hikidoc` in the `Gemfile` was an unused leftover from the `rubima2mobi` migration.

It also fixes the failing CodeQL workflow. The language matrix still listed `go` and `python`, neither of which has any source in the repository, so those two jobs failed with "no source code seen during build". The matrix now covers only `ruby` and `javascript`.

Finally it bumps `github/codeql-action` from `@v2` to `@v4` and `actions/checkout` from `@v3` to `@v5` to clear the CodeQL Action v2 and Node.js 20 deprecation warnings.
