### PR TITLE
Tidy up Gemfile.local generation for tdiary deploy

### DIFF
--- a/hsbt.org/config/deploy.rb
+++ b/hsbt.org/config/deploy.rb
@@ -16,7 +16,7 @@ set :branch, "master"
 set :rbenv_path, "/home/#{fetch(:user)}/.rbenv"
 
 set :bundle_bin, "#{fetch(:rbenv_path)}/shims/bundle"
-set :bundle_withouts, "development test server"
+set :bundle_withouts, "development test server heroku"
 set :bundle_options, -> { }
 
 task :environment do
@@ -29,7 +29,7 @@ task :deploy do
     invoke :"deploy:cleanup"
 
     on :launch do
-      command "echo \"gem 'base64'; gem 'logger'; gem 'fcgi'; gem 'holiday_japan'; gem 'oga'; gem 'rss'\" > #{fetch(:current_path)}/Gemfile.local"
+      command "echo \"gem 'tdiary-style-gfm'; gem 'base64'; gem 'logger'; gem 'fcgi'; gem 'holiday_japan'; gem 'oga'; gem 'rss'\" > #{fetch(:current_path)}/Gemfile.local"
       %w[tdiary-contrib hsbt].each do |dir|
         command "cd #{fetch(:shared_path)}/#{dir}; git pull --rebase"
       end

--- a/hsbt.org/config/deploy.rb
+++ b/hsbt.org/config/deploy.rb
@@ -16,7 +16,7 @@ set :branch, "master"
 set :rbenv_path, "/home/#{fetch(:user)}/.rbenv"
 
 set :bundle_bin, "#{fetch(:rbenv_path)}/shims/bundle"
-set :bundle_withouts, "development test server heroku"
+set :bundle_withouts, "development test server"
 set :bundle_options, -> { }
 
 task :environment do
@@ -36,6 +36,7 @@ task :deploy do
       command "ln -s /home/#{fetch(:user)}/www/tdiary.conf #{fetch(:current_path)}/tdiary.conf"
 
       in_path(fetch(:current_path)) do
+        command "sed -i \"/gem 'tdiary-style-gfm'/d\" Gemfile"
         command "#{fetch(:bundle_bin)} config set without '#{fetch(:bundle_withouts)}'"
         invoke :"bundle:install"
         command "chmod 666 Gemfile.lock"

--- a/hsbt.org/config/deploy.rb
+++ b/hsbt.org/config/deploy.rb
@@ -31,11 +31,9 @@ task :deploy do
     on :launch do
       gemfile_local_gems = %w[
         tdiary-style-gfm
-        base64
         logger
         fcgi
         holiday_japan
-        oga
         rss
       ]
       command "printf \"gem '%s'\\n\" #{gemfile_local_gems.join(" ")} > #{fetch(:current_path)}/Gemfile.local"

--- a/hsbt.org/config/deploy.rb
+++ b/hsbt.org/config/deploy.rb
@@ -29,7 +29,16 @@ task :deploy do
     invoke :"deploy:cleanup"
 
     on :launch do
-      command "echo \"gem 'tdiary-style-gfm'; gem 'base64'; gem 'logger'; gem 'fcgi'; gem 'holiday_japan'; gem 'oga'; gem 'rss'\" > #{fetch(:current_path)}/Gemfile.local"
+      gemfile_local_gems = %w[
+        tdiary-style-gfm
+        base64
+        logger
+        fcgi
+        holiday_japan
+        oga
+        rss
+      ]
+      command "printf \"gem '%s'\\n\" #{gemfile_local_gems.join(" ")} > #{fetch(:current_path)}/Gemfile.local"
       %w[tdiary-contrib hsbt].each do |dir|
         command "cd #{fetch(:shared_path)}/#{dir}; git pull --rebase"
       end


### PR DESCRIPTION
Every deploy printed a Bundler warning because `tdiary-core`'s Gemfile already lists `tdiary-style-gfm` in its optional heroku/docker group and our `Gemfile.local` declared it again. The duplicate check runs at Gemfile parse time, so excluding the group via `without` cannot silence it. Delete the upstream declaration with `sed` before `bundle install` instead.

The `Gemfile.local` generation is now built from a `%w` list for readability. A shell heredoc does not survive Mina's `&&` command joining, so the generation stays a single `printf`. Also drop `oga`, which nothing references anymore, and `base64`, which stays in the lockfile as a declared dependency of `rack-session`.

Generated with [Claude Code](https://claude.com/claude-code)
