### PR TITLE
Align dev and all-ruby with clig.dev and AI-friendly CLI practices

### DIFF
--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -8,6 +8,11 @@ USAGE = <<~TEXT
   usage: all-ruby [--local] [--stable] [--] RUBY-ARGS
          all-ruby --exec [--stable] [--] COMMAND [ARGS...]
 
+  examples:
+    all-ruby -e 'p Comparable.instance_methods.size'  every released Ruby, in the container
+    all-ruby --local --stable -e 'p 1.0 / 3'          only the maintained branches, via mise
+    all-ruby --exec rspec spec/foo_spec.rb            run a command instead of Ruby arguments
+
     --local    run the Rubies mise installed here instead of the container image
     --stable   run only the maintained branches, from mise's x.y-dev installs
     --exec     treat the arguments as a command line rather than as Ruby
@@ -18,10 +23,12 @@ USAGE = <<~TEXT
 
   Without --local this wraps the bundled all-ruby, whose own knobs still apply:
 
-    ALL_RUBY_SINCE=ruby-1.4               run only versions since specified one
-    ALL_RUBY_BINS='ruby-2.4.4 ruby-2.5.1' run only versions specfied
-    ALL_RUBY_ADDBINS=./ruby               run specified commands additionaly
+    ALL_RUBY_SINCE=ruby-1.4               run only versions since the specified one
+    ALL_RUBY_BINS='ruby-2.4.4 ruby-2.5.1' run only the versions specified
+    ALL_RUBY_ADDBINS=./ruby               run the specified commands additionally
     ALL_RUBY_SHOW_DUP=yes                 don't suppress duplicated output
+
+  source: https://github.com/hsbt/hsbt (bootstrap/dotfiles/local/bin/all-ruby)
 TEXT
 
 def which(name)

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -2,6 +2,7 @@
 
 require "json"
 
+VERSION = "1.0.0"
 IMAGE = "ghcr.io/ruby/all-ruby:latest"
 
 USAGE = <<~TEXT
@@ -106,6 +107,9 @@ while ARGV.first&.start_with?("-")
   when "--" then break
   when "-h", "--help"
     puts USAGE
+    exit
+  when "--version"
+    puts "all-ruby #{VERSION} (https://github.com/hsbt/hsbt)"
     exit
   else
     abort "unknown option: #{flag}\n\n#{USAGE}" if flag.start_with?("--")

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -46,7 +46,9 @@ end
 
 def run_container(args, stable)
   runtime = which("container") ? "container" : "podman"
-  command = [runtime, "run", "--rm", "-it", "--arch", "amd64"]
+  command = [runtime, "run", "--rm", "--arch", "amd64"]
+  # Only allocate a terminal when we have one, so pipes and agents work.
+  command << "-it" if $stdin.tty?
 
   if stable
     oldest = dev_branches.first

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -91,14 +91,20 @@ local = false
 stable = false
 exec_mode = false
 
-while ARGV.first&.start_with?("--")
+while ARGV.first&.start_with?("-")
   case (flag = ARGV.shift)
   when "--local" then local = true
   when "--stable" then stable = true
   when "--exec" then exec_mode = local = true
   when "--" then break
-  when "--help" then abort USAGE
-  else abort "unknown option: #{flag}\n\n#{USAGE}"
+  when "-h", "--help"
+    puts USAGE
+    exit
+  else
+    abort "unknown option: #{flag}\n\n#{USAGE}" if flag.start_with?("--")
+    # Single-dash arguments like -e belong to Ruby, not to us.
+    ARGV.unshift(flag)
+    break
   end
 end
 

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -101,6 +101,10 @@ def run_local(args, stable, exec_mode, json)
   end
 
   puts JSON.generate(results) if json
+
+  # A mixed result is a comparison, but everything failing means the command
+  # itself is broken.
+  exit 1 if results.values.none? { |r| r["exit"].zero? }
 end
 
 local = false

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -18,6 +18,7 @@ USAGE = <<~TEXT
     --stable   run only the maintained branches, from mise's x.y-dev installs
     --exec     treat the arguments as a command line rather than as Ruby
                arguments, for running rspec and friends; implies --local
+    --json     with --local, print {"version": {"output": ..., "exit": ...}} JSON
 
   Flags are read until the first non-flag argument. Use `--` when the Ruby
   arguments themselves start with a long option.
@@ -69,12 +70,13 @@ end
 
 # Same shape as the bundled all-ruby: a version column, the output beside it,
 # continuation lines under it, and a trailing `exit N` when the run failed.
-def run_local(args, stable, exec_mode)
+def run_local(args, stable, exec_mode, json)
   versions = stable ? dev_branches : installed_rubies
   abort "mise has no Ruby installed#{" for --stable" if stable}" if versions.empty?
 
   command = exec_mode ? args : ["ruby", *args]
   width = versions.map(&:size).max + 3
+  results = {}
 
   versions.each do |version|
     output = IO.popen(["mise", "exec", "ruby@#{version}", "--", *command], err: %i[child out], &:read)
@@ -84,6 +86,9 @@ def run_local(args, stable, exec_mode)
     # with a screen of warnings about extensions built for another ABI. They
     # say nothing about the command being compared. `gem pristine` is the fix.
     lines = output.split("\n").grep_v(/\AIgnoring .+ because its extensions are not built/)
+    results[version] = { "output" => lines.join("\n"), "exit" => status }
+
+    next if json
     lines << "exit #{status}" unless status.zero?
 
     if lines.empty?
@@ -93,17 +98,21 @@ def run_local(args, stable, exec_mode)
       lines.drop(1).each { |line| puts " " * width + line }
     end
   end
+
+  puts JSON.generate(results) if json
 end
 
 local = false
 stable = false
 exec_mode = false
+json = false
 
 while ARGV.first&.start_with?("-")
   case (flag = ARGV.shift)
   when "--local" then local = true
   when "--stable" then stable = true
   when "--exec" then exec_mode = local = true
+  when "--json" then json = true
   when "--" then break
   when "-h", "--help"
     puts USAGE
@@ -121,8 +130,10 @@ end
 
 abort USAGE if ARGV.empty?
 
+abort "--json requires --local" if json && !local
+
 if local
-  run_local(ARGV, stable, exec_mode)
+  run_local(ARGV, stable, exec_mode, json)
 else
   run_container(ARGV, stable)
 end

--- a/bootstrap/dotfiles/local/bin/all-ruby
+++ b/bootstrap/dotfiles/local/bin/all-ruby
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "did_you_mean"
 require "json"
 
 VERSION = "1.0.0"
@@ -121,7 +122,11 @@ while ARGV.first&.start_with?("-")
     puts "all-ruby #{VERSION} (https://github.com/hsbt/hsbt)"
     exit
   else
-    abort "unknown option: #{flag}\n\n#{USAGE}" if flag.start_with?("--")
+    if flag.start_with?("--")
+      known = %w[--local --stable --exec --json --help --version]
+      hint = DidYouMean::SpellChecker.new(dictionary: known).correct(flag).first
+      abort "unknown option: #{flag}#{" (did you mean: #{hint}?)" if hint}\n\n#{USAGE}"
+    end
     # Single-dash arguments like -e belong to Ruby, not to us.
     ARGV.unshift(flag)
     break

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -5,6 +5,8 @@ require "json"
 require "optparse"
 require "shellwords"
 
+VERSION = "1.0.0"
+
 RUBY_DEV_VERSIONS = %w[3.3 3.4 4.0]
 ALT_RUBIES = %w[jruby truffleruby.graalvm truffleruby-]
 
@@ -472,6 +474,10 @@ parser = OptionParser.new do |o|
   BANNER
 
   o.on("-n", "--dry-run", "Print the commands instead of running them") { $dry_run = true }
+  o.on("--version", "Print the version and source location") do
+    puts "dev #{VERSION} (https://github.com/hsbt/hsbt)"
+    exit
+  end
 end
 parser.parse!(ARGV)
 

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -114,11 +114,6 @@ PACKAGES = {
 XDG_DATA_HOME = ENV["XDG_DATA_HOME"] || File.join(Dir.home, ".local", "share")
 CARGO_HOME = ENV["CARGO_HOME"] || File.join(XDG_DATA_HOME, "cargo")
 
-GIT_GOGET_ROOT = ENV["GIT_GOGET_ROOT"]
-if GIT_GOGET_ROOT.nil? || GIT_GOGET_ROOT.empty?
-  abort 'GIT_GOGET_ROOT is not set. Example: export GIT_GOGET_ROOT="$HOME/Documents"'
-end
-
 GIT_GOGET_URL = "https://raw.githubusercontent.com/hsbt/git-goget/HEAD/git-goget"
 
 TARGETS = %w[brew mise ruby npm cargo go heroku gh git-goget helix source]
@@ -146,8 +141,15 @@ def data_dir(name)
   File.join(XDG_DATA_HOME, name)
 end
 
+# Validated lazily so help and list work without the variable set.
+def goget_root
+  root = ENV["GIT_GOGET_ROOT"].to_s
+  abort 'GIT_GOGET_ROOT is not set. Example: export GIT_GOGET_ROOT="$HOME/Documents"' if root.empty?
+  root
+end
+
 def goget(path)
-  File.join(GIT_GOGET_ROOT, path)
+  File.join(goget_root, path)
 end
 
 module Task
@@ -320,9 +322,9 @@ module Task
   # confirms them, so forks are left alone. Anything dirty or unpushed is
   # reported instead of removed.
   def clean_source
-    repos = Dir.glob(File.join(GIT_GOGET_ROOT, "*", "*", "*"))
+    repos = Dir.glob(File.join(goget_root, "*", "*", "*"))
       .select { |d| File.exist?(File.join(d, ".git")) }
-    puts "scanning #{repos.size} checkouts under #{GIT_GOGET_ROOT}"
+    puts "scanning #{repos.size} checkouts under #{goget_root}"
 
     removed = 0
     repos.group_by { |d| root_commits(d) }.each do |roots, members|
@@ -369,14 +371,14 @@ module Task
   end
 
   def rel(dir)
-    dir.delete_prefix("#{GIT_GOGET_ROOT}/")
+    dir.delete_prefix("#{goget_root}/")
   end
 
   # Fold up the owner directory (and the host directory after it) once the
   # last checkout under it is gone.
   def prune_empty_dirs(stale)
     [File.dirname(stale), File.dirname(File.dirname(stale))].each do |dir|
-      break unless Dir.exist?(dir) && Dir.empty?(dir) && dir != GIT_GOGET_ROOT
+      break unless Dir.exist?(dir) && Dir.empty?(dir) && dir != goget_root
       Dir.rmdir(dir)
     end
   end

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -122,12 +122,16 @@ GIT_GOGET_URL = "https://raw.githubusercontent.com/hsbt/git-goget/HEAD/git-goget
 TARGETS = %w[brew mise ruby npm cargo go heroku gh git-goget helix source]
 VERBS = %w[upgrade reinstall rebuild clean]
 
+# These wipe directories or remove checkouts before doing anything else.
+DESTRUCTIVE_VERBS = %w[reinstall clean]
+
 # Old goget URL parsing left checkouts under these hosts; their twins live
 # under github.com.
 ALIAS_HOSTS = %w[www.github.com wiki.github.com]
 
 $dry_run = false
 $json = false
+$yes = false
 $failures = []
 
 def sh(command, env = {})
@@ -448,6 +452,15 @@ def print_matrix
   end
 end
 
+# Prompt only on a terminal so agents and scripts never hang on stdin.
+def confirm(verb, targets)
+  return unless DESTRUCTIVE_VERBS.include?(verb)
+  return if $yes || $dry_run || !$stdin.tty?
+
+  print "#{verb} #{targets.join(" ")} removes existing files first. Continue? [y/N] "
+  abort "aborted" unless $stdin.gets.to_s.strip.casecmp?("y")
+end
+
 def suggestion(word, candidates)
   hit = DidYouMean::SpellChecker.new(dictionary: candidates).correct(word).first
   hit ? " (did you mean: #{hit}?)" : ""
@@ -487,6 +500,7 @@ parser = OptionParser.new do |o|
 
   o.on("-n", "--dry-run", "Print the commands instead of running them") { $dry_run = true }
   o.on("--json", "Output list as JSON") { $json = true }
+  o.on("-y", "--yes", "Skip the confirmation prompt for reinstall and clean") { $yes = true }
   o.on("--version", "Print the version and source location") do
     puts "dev #{VERSION} (https://github.com/hsbt/hsbt)"
     exit
@@ -507,6 +521,7 @@ when *VERBS
     abort unknown.map { |t| "unknown target: #{t}#{suggestion(t, TARGETS)}" }.join("\n")
   end
 
+  confirm verb, targets
   run verb, targets
   report
 else

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -126,6 +126,7 @@ VERBS = %w[upgrade reinstall rebuild clean]
 ALIAS_HOSTS = %w[www.github.com wiki.github.com]
 
 $dry_run = false
+$json = false
 $failures = []
 
 def sh(command, env = {})
@@ -432,6 +433,11 @@ def run(verb, targets)
   end
 end
 
+def print_matrix_json
+  matrix = TARGETS.to_h { |t| [t, VERBS.to_h { |v| [v, supports?(v, t)] }] }
+  puts JSON.generate(matrix)
+end
+
 def print_matrix
   width = TARGETS.map(&:size).max
   puts ["target".ljust(width), *VERBS].join("  ")
@@ -474,6 +480,7 @@ parser = OptionParser.new do |o|
   BANNER
 
   o.on("-n", "--dry-run", "Print the commands instead of running them") { $dry_run = true }
+  o.on("--json", "Output list as JSON") { $json = true }
   o.on("--version", "Print the version and source location") do
     puts "dev #{VERSION} (https://github.com/hsbt/hsbt)"
     exit
@@ -486,7 +493,7 @@ when nil
   puts parser.help
   exit 1
 when "list"
-  print_matrix
+  $json ? print_matrix_json : print_matrix
 when *VERBS
   targets = ARGV.empty? ? targets_for(verb) : ARGV
   unknown = targets - TARGETS

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -451,6 +451,11 @@ parser = OptionParser.new do |o|
   o.banner = <<~BANNER
     Usage: dev <command> [target...]
 
+    Examples:
+      dev upgrade               Update everything in place
+      dev upgrade ruby npm      Update only the given targets
+      dev -n reinstall cargo    Show what a cargo reinstall would run
+
     Commands:
       upgrade      Update what is installed, in place
       reinstall    Wipe the prefix and install from the package list
@@ -460,6 +465,8 @@ parser = OptionParser.new do |o|
 
     Targets: #{TARGETS.join(" ")}
     With no target, every target supporting the command runs, in the order above.
+
+    Source: https://github.com/hsbt/hsbt (bootstrap/dotfiles/local/bin/dev)
 
     Options:
   BANNER

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "did_you_mean"
 require "fileutils"
 require "json"
 require "optparse"
@@ -447,6 +448,11 @@ def print_matrix
   end
 end
 
+def suggestion(word, candidates)
+  hit = DidYouMean::SpellChecker.new(dictionary: candidates).correct(word).first
+  hit ? " (did you mean: #{hit}?)" : ""
+end
+
 def report
   return if $failures.empty?
 
@@ -497,10 +503,12 @@ when "list"
 when *VERBS
   targets = ARGV.empty? ? targets_for(verb) : ARGV
   unknown = targets - TARGETS
-  abort "unknown target: #{unknown.join(", ")}" unless unknown.empty?
+  unless unknown.empty?
+    abort unknown.map { |t| "unknown target: #{t}#{suggestion(t, TARGETS)}" }.join("\n")
+  end
 
   run verb, targets
   report
 else
-  abort "unknown command: #{verb}\n\n#{parser.help}"
+  abort "unknown command: #{verb}#{suggestion(verb, VERBS + ["list"])}\n\n#{parser.help}"
 end

--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -234,7 +234,7 @@ module Task
 
   def relink(path, target)
     if File.exist?(path) && !File.symlink?(path)
-      puts "==> skip #{path} (real install, not a symlink)"
+      warn "==> skip #{path} (real install, not a symlink)"
       return
     end
 
@@ -342,9 +342,9 @@ module Task
         label = "#{rel(stale)} (duplicate of #{rel(kept)})"
 
         if dirty?(stale)
-          puts "==> skip #{label}: uncommitted changes"
+          warn "==> skip #{label}: uncommitted changes"
         elsif unpushed?(stale)
-          puts "==> skip #{label}: unpushed commits"
+          warn "==> skip #{label}: unpushed commits"
         else
           puts "==> rm -rf #{label}"
           unless $dry_run
@@ -429,7 +429,7 @@ end
 def run(verb, targets)
   targets.each do |target|
     unless supports?(verb, target)
-      puts "", "--- skip #{target}: no #{verb} step ---"
+      warn "", "--- skip #{target}: no #{verb} step ---"
       next
     end
 


### PR DESCRIPTION
`dev` and `all-ruby` hit avoidable failures under scripts and coding agents. `dev --help` aborted when `GIT_GOGET_ROOT` was unset, `all-ruby --help` exited 1 through stderr, and the container mode always passed `-it`, which breaks piped runs.

This aligns both commands with clig.dev and AI-friendly CLI practices. Help now leads with examples and points back to this repository, both commands gained `--version`, and `dev list --json` and `all-ruby --local --json` provide machine-readable output. Unknown commands and options get did-you-mean suggestions. `dev reinstall` and `dev clean` now confirm on a terminal, with `-y` to skip, and stay prompt-free when stdin is not a TTY. `all-ruby --local` exits 1 when every version fails, since that means the given command itself is broken.
