### PR TITLE
Remove navi_admin from my_navi tdiary plugin

### DIFF
--- a/hsbt.org/tdiary-plugin/my_navi.rb
+++ b/hsbt.org/tdiary-plugin/my_navi.rb
@@ -1,13 +1,13 @@
 # my_navi.rb プラグイン
 #
 # 通常のnaviに、カレンダーとRSS feedのアイコンを追加。
+# 追記・編集はssh トンネル経由でのみ行うため、navi_admin(追記/編集リンク)は出力しない。
 # dropdown_calendar.rbを有効にしておくこと。
 # @options['dropdown_calendar.label']は空('')にしておく。
 def navi
   result = %(<div class="adminmenu">\n)
   result << calendar
   result << navi_user
-  result << navi_admin
   result << %(<a href="index.rdf"><img style="border-width: 0px;" src="https://www.hsbt.org/diary/images/feed-icon-12x12.png" width="12" height="12" alt="RSS feed"></a>)
   result << %(</div>)
 end


### PR DESCRIPTION
The tDiary update interface on www.hsbt.org is now reachable only through an ssh tunnel, so the append and edit links that `navi_admin` renders are dead ends for public visitors. This drops the `navi_admin` call from the `my_navi.rb` plugin so the nav bar shows only the calendar, date navigation, and the RSS feed icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
