### PR TITLE
Always answer yes to Homebrew ask mode in dev upgrade

### DIFF
--- a/bootstrap/dotfiles/local/bin/dev
+++ b/bootstrap/dotfiles/local/bin/dev
@@ -167,8 +167,9 @@ module Task
   module_function
 
   def upgrade_brew
-    sh "brew upgrade"
-    sh "brew upgrade --cask"
+    # Homebrew 6 defaults to ask mode; --yes skips the confirmation prompt.
+    sh "brew upgrade --yes"
+    sh "brew upgrade --cask --yes"
     sh "brew autoremove"
     sh "brew cleanup"
   end


### PR DESCRIPTION
Homebrew 6 made ask mode the default, so `dev upgrade` now stops at an interactive `Do you want to proceed with the upgrade? [y/n]` prompt during `brew upgrade`. This adds `--yes` to the `brew upgrade` and `brew upgrade --cask` invocations so the upgrade always proceeds without confirmation.
